### PR TITLE
Fix bug loading datasets with a train split

### DIFF
--- a/torchtitan/datasets/preprocessed.py
+++ b/torchtitan/datasets/preprocessed.py
@@ -32,7 +32,19 @@ class PreprocessedDataset(IterableDataset, Stateful):
         infinite: bool = False,
         shuffle_seed: int | None = 42,
     ) -> None:
-        ds = load_dataset(dataset_path if dataset_path else dataset_name, split="train")
+        # Load preprocessed dataset from disk using load_from_disk
+        # This assumes the dataset has already been processed and saved to disk
+        ds_dict = load_dataset(dataset_path if dataset_path else dataset_name)
+        
+        # Extract the train split from the DatasetDict
+        # You can change 'train' to whatever split you want to use
+        if 'train' in ds_dict:
+            ds = ds_dict['train']
+        else:
+            # If no 'train' split, use the first available split
+            split_name = list(ds_dict.keys())[0]
+            ds = ds_dict[split_name]
+            logger.info(f"No 'train' split found, using '{split_name}' split instead")
 
         if shuffle_seed is not None:
             ds = ds.shuffle(shuffle_seed)


### PR DESCRIPTION
Updates the preprocessed dataloader to ingest the train split, if it exists 

Caused the following issue prior

```[rank0]:[titan] 2025-07-29 20:01:29,003 - root - INFO - Starting job: Qwen3 14B Hermes 4 Full Training
[rank0]:[titan] 2025-07-29 20:01:31,317 - root - WARNING - ENV[TORCH_NCCL_ASYNC_ERROR_HANDLING] = 1 will be overridden to 3 based on job config
[rank0]:[titan] 2025-07-29 20:01:31,320 - root - INFO - Building 1-D device mesh with ['dp_shard'], [8]
[rank0]:[titan] 2025-07-29 20:01:31,322 - root - INFO - [GC] Initial GC collection. 0.00 seconds.
[rank0]:[titan] 2025-07-29 20:01:35,426 - root - INFO - Loading tokenizer from tokenizer.json
[rank0]:[titan] 2025-07-29 20:01:36,190 - root - INFO - Loaded preprocessed dataset with 1 samples
[rank0]:[rank0]: Traceback (most recent call last):
[rank0]:[rank0]:   File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
[rank0]:[rank0]:     return _run_code(code, main_globals, None,
[rank0]:[rank0]:   File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
[rank0]:[rank0]:     exec(code, run_globals)
[rank0]:[rank0]:   File "/home/teknium/torchtitan/torchtitan/train.py", line 586, in <module>
[rank0]:[rank0]:     trainer = Trainer(config)
[rank0]:[rank0]:   File "/home/teknium/torchtitan/venv/lib/python3.10/site-packages/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 357, in wrapper
[rank0]:[rank0]:     return f(*args, **kwargs)
[rank0]:[rank0]:   File "/home/teknium/torchtitan/torchtitan/train.py", line 132, in __init__
[rank0]:[rank0]:     self.dataloader = self.train_spec.build_dataloader_fn(
[rank0]:[rank0]:   File "/home/teknium/torchtitan/torchtitan/datasets/dataloader.py", line 35, in build_dataloader
[rank0]:[rank0]:     return dataloader(dp_world_size, dp_rank, tokenizer, job_config, infinite)
[rank0]:[rank0]:   File "/home/teknium/torchtitan/torchtitan/datasets/preprocessed.py", line 164, in build_preprocessed_dataloader
[rank0]:[rank0]:     ds = PreprocessedDataset(
[rank0]:[rank0]:   File "/home/teknium/torchtitan/torchtitan/datasets/preprocessed.py", line 44, in __init__
[rank0]:[rank0]:     self._data = split_dataset_by_node(ds, dp_rank, dp_world_size)
[rank0]:[rank0]:   File "/home/teknium/torchtitan/venv/lib/python3.10/site-packages/datasets/distributed.py", line 39, in split_dataset_by_node
[rank0]:[rank0]:     return _split_by_node_iterable_dataset(dataset, rank=rank, world_size=world_size)
[rank0]:[rank0]:   File "/home/teknium/torchtitan/venv/lib/python3.10/site-packages/datasets/iterable_dataset.py", line 4438, in _split_by_node_iterable_dataset
[rank0]:[rank0]:     if dataset._distributed:
[rank0]:[rank0]: AttributeError: 'DatasetDict' object has no attribute '_distributed'
```  

When doing load_dataset() on the dataset in question, returned this info:
```
Resolving data files: 100%|██████████████████████████████████████████████████████████████████████████████████| 64/64 [00:00<00:00, 314327.23it/s]
Loading dataset shards: 100%|█████████████████████████████████████████████████████████████████████████████████| 64/64 [00:00<00:00, 21469.68it/s]
Dataset type: <class 'datasets.dataset_dict.DatasetDict'>
Dataset keys: ['train']
Length: 1
Split 'train' length: 367456
[None]
```  

The length was 1, which when loaded by the dataloader, was crashing due to trying to distribute it. The length was 1 because the actual dataset entries were inside the 1 split that exists, `train`