### PR TITLE
Accumulate n_tokens_seen from fwd/bwd step to calculate MFU/Throughput

### DIFF
--- a/torchtitan/grpo_train.py
+++ b/torchtitan/grpo_train.py
@@ -965,6 +965,8 @@ class Trainer(torch.distributed.checkpoint.stateful.Stateful):
                 nb_loss = nb_loss
                 loss += nb_loss.mean().item() / len(microbatches)
                 self.ntokens_seen += n_tokens_seen
+                # Accumulate tokens for MFU/throughput computation
+                self.metrics_processor.ntokens_since_last_log += n_tokens_seen
 
             grad_norm = dist_utils.clip_grad_norm_(
                 [p for m in self.model_parts for p in m.parameters()],


### PR DESCRIPTION
- Fixed accum ntokens_since_last_log of n_tokens_seen from forward_backward_step
<img width="859" height="644" alt="image" src="https://github.com/user-attachments/assets/7050b6d9-3039-4eaa-b6b6-0a89bb981032" />

- The MetricsProcessor calculates it like so

``` py
time_delta = time.perf_counter() - self.time_last_log

# tokens per second per device, abbreviated as tps
tps = self.ntokens_since_last_log / (
    time_delta * self.parallel_dims.non_data_parallel_size
)
# model FLOPS utilization
# For its definition and calculation, please refer to the PaLM paper:
# https://arxiv.org/abs/2204.02311
mfu = 100 * self.num_flops_per_token * tps / self.gpu_peak_flops
tflops = self.num_flops_per_token * tps / 1e12
```