### PR TITLE
[Fix] Using gloo backend for DCP checkpoint coordination to prevent OOM on high memory MoE models

### DIFF
--- a/torchtitan/tools/utils.py
+++ b/torchtitan/tools/utils.py
@@ -58,10 +58,18 @@ class GarbageCollection:
             self.collect("Performing periodic GC collection")
 
     @staticmethod
-    def collect(reason: str, generation: int = 1):
+    def collect(reason: str, generation: int = 1, empty_cuda_cache: bool = False):
         begin = time.monotonic()
         gc.collect(generation)
-        logger.info("[GC] %s took %.2f seconds", reason, time.monotonic() - begin)
+        if empty_cuda_cache and torch.cuda.is_available():
+            torch.cuda.empty_cache()
+            logger.info(
+                "[GC] %s took %.2f seconds (with CUDA cache cleared)",
+                reason,
+                time.monotonic() - begin,
+            )
+        else:
+            logger.info("[GC] %s took %.2f seconds", reason, time.monotonic() - begin)
 
 
 # hardcoded BF16 type peak flops for NVIDIA A100, H100, H200, B200 GPU and AMD MI250, MI300X, MI325X, MI355X and Intel PVC


### PR DESCRIPTION
Fix checkpoint OOM that occurs when saving models with high GPU memory usage (98%+), such as fine-grained MoE models.                                                           
                                                                                                                                                                                  
  Problem                                                                                                                                                                         
                                                                                                                                                                                  
  Checkpointing fails with OOM during dist.gather_object() in DCP (Distributed Checkpoint) plan coordination, even though the actual checkpoint data fits in memory.              
                                                                                                                                                                                  
  **Root Cause**                                                                                                                                                                      
                                                                                                                                                                                  
  NCCL backend allocates GPU buffers for collective operations, including small metadata exchanges during DCP coordination. When GPU memory is near capacity, these additional    
  allocations trigger OOM.                                                                                                                                                        
                                                                                                                                                                                  
  **Changes**                                                                                                                                                                         
                                                                                                                                                                                  
  1. Always use gloo process group for checkpoint operations - Gloo uses CPU memory instead of GPU memory for coordination                                                        
  2. Pass gloo to synchronous dcp.save() - Previously only async mode used gloo                                                                                                   
  3. Clear CUDA cache before checkpoint - Added empty_cuda_cache option to GarbageCollection.collect() to free fragmented GPU memory before DCP operations                        
                                                                                                                                                                                  
  **Testing**                                                                                                                                                                         
                                                                                                                                                                                  
  Tested with 5B parameter MoE model (E=128, k=2) at 98.2% GPU memory:                                                                                                            
  - Before: OOM at checkpoint step                                                                                                                                                
  - After: Checkpoint saves successfully in ~33 seconds                                                                                                                           
                                                                                                                                                                                  
  **Performance Impact**                                                                                                                                                              
                                                                                                                                                                                  
  - Training throughput: No change (gloo only used during checkpoint)                                                                                                             
  - Checkpoint time: Negligible increase (<1s for metadata exchange)                                                                                                              