### PR TITLE
fix: restore shared_gate gating logic in MoE forward pass

### DIFF
--- a/torchtitan/models/moe/moe.py
+++ b/torchtitan/models/moe/moe.py
@@ -704,7 +704,12 @@ class MoE(nn.Module):
             routed_output = self.experts(x, num_tokens_per_expert)
             # shared expert
             if self.shared_experts is not None:
-                out = self.shared_experts(x)
+                shared_out = self.shared_experts(x)
+                if self.shared_gate is not None:
+                    shared_gate_val = F.sigmoid(self.shared_gate(x))
+                    out = shared_out * shared_gate_val
+                else:
+                    out = shared_out
             else:
                 out = torch.zeros_like(x)
             out = routed_output + out
@@ -746,7 +751,12 @@ class MoE(nn.Module):
             # Note: we execute the shared expert before scoring the output of the routed expert
             # to "implicitly" overlap the shared expert compute with token combine communication
             if self.shared_experts is not None:
-                out = self.shared_experts(x)
+                shared_out = self.shared_experts(x)
+                if self.shared_gate is not None:
+                    shared_gate_val = F.sigmoid(self.shared_gate(x))
+                    out = shared_out * shared_gate_val
+                else:
+                    out = shared_out
             else:
                 out = torch.zeros_like(x)
 


### PR DESCRIPTION
- Restores the `shared_gate` sigmoid gating logic that was accidentally removed during DeepEP
  integration
- The `shared_gate` parameter was being initialized and weights loaded correctly, but never used in
  the forward pass


## Problem

  In commit `fa525fc`, the shared expert computation was simplified and the `shared_gate` logic was
  removed:

  ```python
  # Before (broken):
  if self.shared_experts is not None:
      out = self.shared_experts(x)

  # After (fixed):
  if self.shared_experts is not None:
      shared_out = self.shared_experts(x)
      if self.shared_gate is not None:
          shared_gate_val = F.sigmoid(self.shared_gate(x))
          out = shared_out * shared_gate_val
      else:
          out = shared_out
 ```

  This caused models with shared_gate=True (e.g., qwen3_next) to:
  - Load weights correctly
  - Initialize weights correctly
  - But ignore them during forward pass

### Test plan

  | Test                 | Path       | shared_gate | GPUs | Result  |
  |----------------------|------------|-------------|------|---------|
  | Baseline             | Non-DeepEP | False       | 1    | ✅ Pass |
  | shared_gate          | Non-DeepEP | True        | 1    | ✅ Pass |
  | shared_gate + EP     | Non-DeepEP | True        | 8    | ✅ Pass |
  | shared_gate + DeepEP | DeepEP     | True        | 8    | ✅ Pass |
  | Pre-commit           | -          | -           | -    | ✅ Pass |